### PR TITLE
Added some domain return status constants

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -8,6 +8,11 @@ import (
 	"github.com/oze4/godaddygo/internal/exception"
 )
 
+const (
+	StatusActive    = "ACTIVE"
+	StatusCancelled = "CANCELLED"
+)
+
 func newDomain(config *Config) domain {
 	return domain{config}
 }


### PR DESCRIPTION
**What?**
Added constants for active and cancelled domain states.

**Why?**
In order to properly process the status of a domain it would be great to have some constants available for that. The problem is that Godaddy's API has a gazillion of return code here[0]. Not sure if it makes sense to include them all as this will bloat the code base dramatically.  

[0] https://developer.godaddy.com/doc/endpoint/domains#/v1/list